### PR TITLE
First pipeline

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,35 @@
+name: build and release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+  
+    - name: Run build
+      env:
+        GITHUB_RUN_NUMBER: ${{ github.run_number }}
+      run: |
+        . ${{ github.workspace }}/build.ps1 -Verbose
+      shell: pwsh
+    
+    - name: publish to PSGallery
+      env:
+        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+      shell: pwsh
+      run: |
+        Get-ChildItem "${{ github.workspace }}/bin/release/pwsh.frontmatter" -recurse
+        Publish-Module -Path "${{ github.workspace }}bin/release/pwsh.frontmatter" -NuGetApiKey $env:NUGET_KEY -Verbose
+    
+    - name: Archive current build
+      uses: actions/upload-artifact@v4
+      with:
+        name: builtModule
+        path: "${{ github.workspace }}/bin/release/pwsh.frontmatter"

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 [cmdletbinding()]
 param (
     [parameter(Mandatory = $false)]
-    [System.IO.FileInfo]$ModulePath = "$PSScriptRoot\pwsh.frontmatter",
+    [System.IO.FileInfo]$ModulePath = "$PSScriptRoot/pwsh.frontmatter",
 
     [parameter(Mandatory = $false)]
     [switch]$BuildLocal,
@@ -15,25 +15,31 @@ try {
     $moduleName = Split-Path -Path $ModulePath -Leaf
     $PreviousVersion = Find-Module -Name $moduleName -ErrorAction SilentlyContinue | Select-Object *
     [Version]$exVer = $PreviousVersion ? $PreviousVersion.Version : $null
-    if ($CleanBuildDirectory -and $(Test-Path "$PSScriptRoot\bin\release\*")) {
+    if ($CleanBuildDirectory -and $(Test-Path "$PSScriptRoot/bin/release/*")) {
         Write-Host "Cleaning build directory.."
-        $null = Remove-Item -Path "$PSScriptRoot\bin\release\*" -Recurse -Force
+        $null = Remove-Item -Path "$PSScriptRoot/bin/release/*" -Recurse -Force
     }
     if ($BuildLocal) {
-        $rev = ((Get-ChildItem -Path "$PSScriptRoot\bin\release\" -ErrorAction SilentlyContinue).Name | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum) + 1
+        [int]$rev = ((Get-ChildItem -Path "$PSScriptRoot/bin/release/" -ErrorAction SilentlyContinue).Name | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum) + 1
         $newVersion = New-Object -TypeName Version -ArgumentList 1, 0, 0, $rev
     }
     else {
         $newVersion = if ($exVer) {
-            $rev = ($exVer.Revision + 1)
+            [int]$rev = ($exVer.Revision + 1)
             New-Object version -ArgumentList $exVer.Major, $exVer.Minor, $exVer.Build, $rev
         }
+        elseif (-not ([string]::IsNullOrEmpty($env:BUILD_BUILDID))) {
+            Write-Verbose 'We are in Azure DevOps it seems...'
+            [int]$rev = $env:BUILD_BUILDID
+            New-Object Version -ArgumentList 1, 0, 0, $rev
+        }
         else {
-            $rev = ((Get-ChildItem "$PSScriptRoot\bin\release\" -ErrorAction SilentlyContinue).Name | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum) + 1
+            Write-Verbose 'Assume GitHub'
+            [int]$rev = $env:GITHUB_RUN_NUMBER
             New-Object Version -ArgumentList 1, 0, 0, $rev
         }
     }
-    $releaseNotes = (Get-Content ".\$moduleName\releaseNotes.txt" -Raw -ErrorAction SilentlyContinue).Replace("{{NewVersion}}", $newVersion)
+    $releaseNotes = (Get-Content "$ModulePath/ReleaseNotes.txt" -Raw -ErrorAction SilentlyContinue).Replace("{{NewVersion}}", $newVersion)
     if ($PreviousVersion) {
         $releaseNotes = @"
 $releaseNotes
@@ -45,10 +51,10 @@ $($previousVersion.releaseNotes)
 
     #region Build out the release
     if ($BuildLocal) {
-        $relPath = "$PSScriptRoot\bin\release\$rev\$moduleName"
+        $relPath = "$PSScriptRoot/bin/release/$rev/$moduleName"
     }
     else {
-        $relPath = "$PSScriptRoot\bin\release\$moduleName"
+        $relPath = "$PSScriptRoot/bin/release/$moduleName"
     }
     "Version is $newVersion"
     "Module Path is $ModulePath"
@@ -58,13 +64,13 @@ $($previousVersion.releaseNotes)
         New-Item -Path $relPath -ItemType Directory -Force | Out-Null
     }
 
-    Copy-Item -Path "$ModulePath\*" -Destination "$relPath" -Recurse -Exclude ".gitKeep", "releaseNotes.txt", "description.txt"
+    Copy-Item -Path "$ModulePath/*" -Destination "$relPath" -Recurse -Exclude ".gitKeep", "releaseNotes.txt", "description.txt"
 
     $Manifest = @{
-        Path              = "$relPath\$moduleName.psd1"
+        Path              = "$relPath/$moduleName.psd1"
         ModuleVersion     = $newVersion
-        Description       = (Get-Content "$ModulePath\description.txt" -Raw).ToString()
-        FunctionsToExport = (Get-ChildItem -Path "$relPath\Public\*.ps1" -Recurse).BaseName
+        Description       = (Get-Content "$ModulePath/description.txt" -Raw).ToString()
+        FunctionsToExport = (Get-ChildItem -Path "$relPath/public/*.ps1" -Recurse).BaseName
         ReleaseNotes      = $releaseNotes
     }
     Update-ModuleManifest @Manifest

--- a/pwsh.frontmatter/pwsh.frontmatter.psd1
+++ b/pwsh.frontmatter/pwsh.frontmatter.psd1
@@ -10,7 +10,7 @@
         PSData = @{
             Tags = @('frontmatter', 'pwsh')
             LicenseUri = 'https://opensource.org/licenses/MIT'
-            ProjectUri = 'https://github.com/your-repo'
+            ProjectUri = 'https://github.com/tabs-not-spaces/pwsh.frontmatter'
             IconUri = 'https://example.com/icon.png'
         }
     }


### PR DESCRIPTION
- Adds a pipeline triggered on main and workflow dispatch
  - Additional publish the built artifact in the pipeline run for easier download / test / verification
- Changes path separators and casings in build script to work on ubuntu hosted runners
- fixes the link in the module manifest to the source repo so published module will point to the correct repository

In order for the workflow publish to run you _must_ create a repository secret with your nuget API key. Name is set to `NUGET_KEY` - See line 25 in the workflow YAML.